### PR TITLE
Reduce full range joint limits by 0.002

### DIFF
--- a/tams_ur5_description/config/joint_ranges/default.yaml
+++ b/tams_ur5_description/config/joint_ranges/default.yaml
@@ -3,40 +3,44 @@
 # Default limits are 2.0 * pi = 6.2831853 for all joints except
 # for elbow_joint. elbow_joint is restricted to +/-pi due to hardware
 # limitations.
+#
+# Limits that align with the robots joint limits (+/- 2*pi) may allow
+# joint configurations that lead to protective stop.
+# To prevent that we substract a safety tolerance of 0.002.
 # 
 # shoulder_pan_joint:
-#     lower: -6.2831853
-#     upper: 6.2831853
+#     lower: -6.2811853
+#     upper: 6.2811853
 # shoulder_lift_joint:
-#     lower: -6.2831853
-#     upper: 6.2831853
+#     lower: -6.2811853
+#     upper: 6.2811853
 # elbow_joint: 
 #     lower: -3.1415926
 #     upper: 3.1415926
 # wrist_1_joint:
-#     lower: -6.2831853
-#     upper: 6.2831853
+#     lower: -6.2811853
+#     upper: 6.2811853
 # wrist_2_joint:
-#     lower: -6.2831853
-#     upper: 6.2831853
+#     lower: -6.2811853
+#     upper: 6.2811853
 # wrist_3_joint:
-#     lower: -6.2831853
-#     upper: 6.2831853
+#     lower: -6.2811853
+#     upper: 6.2811853
 shoulder_pan_joint:
-    lower: -6.2831853
-    upper: 6.2831853
+    lower: -6.2811853
+    upper: 6.2811853
 shoulder_lift_joint:
-    lower: -6.2831853
-    upper: 6.2831853
+    lower: -6.2811853
+    upper: 6.2811853
 elbow_joint: 
     lower: -3.1415926
     upper: 3.1415926
 wrist_1_joint:
-    lower: -6.2831853
-    upper: 6.2831853
+    lower: -6.2811853
+    upper: 6.2811853
 wrist_2_joint:
     lower: -3.1415926
     upper: 3.1415926
 wrist_3_joint:
-    lower: -6.2831853
-    upper: 6.2831853
+    lower: -6.2811853
+    upper: 6.2811853

--- a/tams_ur5_description/config/joint_ranges/elbow_up.yaml
+++ b/tams_ur5_description/config/joint_ranges/elbow_up.yaml
@@ -2,6 +2,10 @@
 # Specifies the upper and lower limits of ur5 joints in the urdf.
 # elbow_up restricts the arm to move like an excavator.
 # The purpose is to prevent undesired flipping motions.
+#
+# Limits that align with the robots joint limits (+/- 2*pi) may allow
+# joint configurations that lead to protective stop.
+# To prevent that we substract a safety tolerance of 0.002.
 shoulder_pan_joint:
     lower: -3.1415926
     upper: 1.570796    
@@ -12,11 +16,11 @@ elbow_joint:
     lower: -3.1415926
     upper: 0.0
 wrist_1_joint:
-    lower: -6.2831853
-    upper: 6.2831853
+    lower: -6.2811853
+    upper: 6.2811853
 wrist_2_joint:
     lower: -3.1415926
     upper: 3.1415926
 wrist_3_joint:
-    lower: -6.2831853
-    upper: 6.2831853
+    lower: -6.2811853
+    upper: 6.2811853


### PR DESCRIPTION
Joint limits of +/-2*pi allow configurations that invalidate the safety tolerance of the arm. 
In some instances this leads to a protective stop of the robot since joint positions are too close to the limits. We reduce this limits by a small value to prevent this issue when planning with MoveIt.