### PR TITLE
Deprecated: xacro tag 'insert_block' w/o 'xacro:' xml namespace

### DIFF
--- a/tams_ur5_description/urdf/ft_adapter.urdf.xacro
+++ b/tams_ur5_description/urdf/ft_adapter.urdf.xacro
@@ -29,7 +29,7 @@
       </collision>
     </link>
     <joint name="${name}_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <child link="${name}" />
       <parent link="${parent}"/>
     </joint>

--- a/tams_ur5_description/urdf/mounted_camera.urdf.xacro
+++ b/tams_ur5_description/urdf/mounted_camera.urdf.xacro
@@ -29,7 +29,7 @@
       </collision>
     </link>
 <joint name="mounted_holder_joint" type="fixed">
-       <insert_block name="origin" />
+       <xacro:insert_block name="origin" />
       <child link="mounted_holder" />
       <parent link="${parent}"/>
     </joint>

--- a/tams_ur5_description/urdf/plug_collision_model.urdf.xacro
+++ b/tams_ur5_description/urdf/plug_collision_model.urdf.xacro
@@ -21,7 +21,7 @@
       </collision>
     </link>
     <joint name="${name}_link_1_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <child link="${name}_link_1" />
       <parent link="${parent}"/>
     </joint>
@@ -44,7 +44,7 @@
       </collision>
     </link>
     <joint name="${name}_link_2_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <child link="${name}_link_2" />
       <parent link="${parent}"/>
     </joint>

--- a/tams_ur5_description/urdf/s_model_adapter.urdf.xacro
+++ b/tams_ur5_description/urdf/s_model_adapter.urdf.xacro
@@ -44,7 +44,7 @@
       </collision>
     </link>
     <joint name="${name}_joint" type="fixed">
-      <insert_block name="origin" />
+      <xacro:insert_block name="origin" />
       <child link="${name}" />
       <parent link="${parent}"/>
     </joint>


### PR DESCRIPTION
Deprecated: xacro tag 'insert_block' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)

Use the following command to fix incorrect tag usage:
`find . -iname "*.xacro" | xargs sed -i 's#<\([/]\?\)\(if\|unless\|include\|arg\|property\|macro\|insert_block\)#<\1xacro:\2#g'`
